### PR TITLE
Do not set MaxConcurrentRuns and WorkerType by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ custom:
 |glueVersion|String|Indicate language and glue version to use ( `[language][version]-[glue version]`) the value can you use are: <ul><li>python3-1.0</li><li>python3-2.0</li><li>python2-1.0</li><li>python2-0.9</li><li>scala2-1.0</li><li>scala2-0.9</li><li>scala2-2.0</li></ul>|true|
 |role|String| arn role to execute job|true|
 |MaxConcurrentRuns|Double|max concurrent runs of the job|false|
-|WorkerType|String|worker type, default value if you dont indicate is `Standart`|false|
+|WorkerType|String|The type of predefined worker that is allocated when a job runs. Accepts a value of Standard, G.1X, or G.2X.|false|
 |NumberOfWorkers|Integer|number of workers|false|
 
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ custom:
 |glueVersion|String|Indicate language and glue version to use ( `[language][version]-[glue version]`) the value can you use are: <ul><li>python3-1.0</li><li>python3-2.0</li><li>python2-1.0</li><li>python2-0.9</li><li>scala2-1.0</li><li>scala2-0.9</li><li>scala2-2.0</li></ul>|true|
 |role|String| arn role to execute job|true|
 |MaxConcurrentRuns|Double|max concurrent runs of the job|false|
-|WorkerType|String|worker type, default value if you dont indicate is `Standar`|false|
+|WorkerType|String|worker type, default value if you dont indicate is `Standart`|false|
 |NumberOfWorkers|Integer|number of workers|false|
 
 

--- a/src/domain/glue-job.js
+++ b/src/domain/glue-job.js
@@ -53,8 +53,12 @@ export default class GlueJob {
 
     setOnlyPropertiesSpark(cfn) {
         if (this.commandName === 'glueetl') {
-            cfn.Properties.WorkerType = (this.WorkerType) ? this.WorkerType : 'Standar';
-            cfn.Properties.NumberOfWorkers = (this.NumberOfWorkers) ? this.NumberOfWorkers : '';
+            if (this.WorkerType) {
+                cfn.Properties.WorkerType = this.WorkerType
+            }
+            if (this.NumberOfWorkers) {
+                cfn.Properties.NumberOfWorkers = this.NumberOfWorkers
+            }
         }
 
         return cfn;


### PR DESCRIPTION
Currently default values for both MaxConcurrentRuns and WorkerType are wrong, i.e. MaxConcurrentRuns gets an empty string instead of integer and WorkerType default value is misspelled.

But instead of enforcing hard coded default values I suggest to not populate this values by default at all and let CloudFormation decide on default values.