### PR TITLE
Allow providing custom tempDir for Glue jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ custom:
   Glue:
     bucketDeploy: someBucket # Required
     s3Prefix: some/s3/key/location/ # optional, default = 'glueJobs/'
+    tempDirBucket: someBucket # optional, default = '{serverless.serviceName}-{provider.stage}-gluejobstemp' 
+    tempDirS3Prefix: some/s3/key/location/ # optional, default = ''. The job name will be appended to the prefix name
     jobs:
       - job:
           name: super-glue-job # Required
@@ -57,6 +59,9 @@ custom:
 |Parameter|Type|Description|Required|
 |-|-|-|-|
 |bucketDeploy|String|S3 Bucket name|true|
+|s3Prefix|String|S3 prefix name|false|
+|tempDirBucket|String|S3 Bucket name for Glue temporary directory|false|
+|tempDirS3Prefix|String|S3 prefix name for Glue temporary directory|false|
 |jobs|Array|Array of glue jobs to deploy|true|
 
 ### Jobs configurations parameters


### PR DESCRIPTION
Currently the tempDir for Glue jobs can only be automatically generated. Often creating a new bucket is not an option, so it would be useful if plugin supported a custom bucket and s3 prefix for temporary directory. 

Added 2 new parameters to the configuration that jobs will use if tempDir is true.

Also added s3Prefix description to the table describing the global configuration in the README. It was missing..