### PR TITLE
Add support for custom default arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Glue:
         continuousLogConversionPattern: string # Optional
         enableSparkUi: string # Optional
         sparkEventLogsPath: string # Optional
-        customDefaultArguments: # Optional; these are user-specified custom default arguments that are passed into cloudformation as-is into the defaultArguments object
-          --custom_arg_1: custom_value
-          --custom_arg_2: other_custom_value
+        customDefaultArguments: # Optional; these are user-specified custom default arguments that are passed into cloudformation with a leading -- (required for glue)
+          custom_arg_1: custom_value
+          custom_arg_2: other_custom_value
   triggers:
     - name: some-trigger-name # Required
       schedule: 30 12 * * ? * # Optional, CRON expression. The trigger will be created with On-Demand type if the schedule is not provided.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Glue:
         continuousLogConversionPattern: string # Optional
         enableSparkUi: string # Optional
         sparkEventLogsPath: string # Optional
+        customDefaultArguments: # Optional; these are user-specified custom default arguments that are passed into cloudformation as-is into the defaultArguments object
+          --custom_arg_1: custom_value
+          --custom_arg_2: other_custom_value
   triggers:
     - name: some-trigger-name # Required
       schedule: 30 12 * * ? * # Optional, CRON expression. The trigger will be created with On-Demand type if the schedule is not provided.
@@ -91,7 +94,7 @@ you can define a lot of jobs..
         scriptPath: scriptA
         ...
       - name: jobB
-        script: scriptB
+        scriptPath: scriptB
         ...
 
 ```

--- a/src/domain/default-arguments.ts
+++ b/src/domain/default-arguments.ts
@@ -24,5 +24,5 @@ export class DefaultArguments implements DefaultArgumentsInterface {
   enableSparkUi?: string | undefined;
   sparkEventLogsPath?: string | undefined;
   tempDir?: any;
-  customDefaultArguments?: Map<string, string> | undefined;
+  customArguments?: Map<string, string> | undefined;
 }

--- a/src/domain/default-arguments.ts
+++ b/src/domain/default-arguments.ts
@@ -24,4 +24,5 @@ export class DefaultArguments implements DefaultArgumentsInterface {
   enableSparkUi?: string | undefined;
   sparkEventLogsPath?: string | undefined;
   tempDir?: any;
+  customDefaultArguments?: Map<string, string> | undefined;
 }

--- a/src/interfaces/default-arguments.interface.ts
+++ b/src/interfaces/default-arguments.interface.ts
@@ -22,4 +22,5 @@ export interface DefaultArgumentsInterface {
   continuousLogConversionPattern?: string;
   enableSparkUi?: string;
   sparkEventLogsPath?: string;
+  customDefaultArguments?: Map<string,string>;
 }

--- a/src/interfaces/default-arguments.interface.ts
+++ b/src/interfaces/default-arguments.interface.ts
@@ -22,5 +22,5 @@ export interface DefaultArgumentsInterface {
   continuousLogConversionPattern?: string;
   enableSparkUi?: string;
   sparkEventLogsPath?: string;
-  customDefaultArguments?: Map<string,string>;
+  customArguments?: Map<string,string>;
 }

--- a/src/utils/cloud-formation.utils.ts
+++ b/src/utils/cloud-formation.utils.ts
@@ -55,6 +55,13 @@ export class CloudFormationUtils {
         Tags: glueJob.Tags,
       },
     };
+    if (glueJob.DefaultArguments.customDefaultArguments) {
+      Object.keys(glueJob.DefaultArguments.customDefaultArguments).forEach(key => {
+        if (!cfn.Properties.DefaultArguments[key]) {
+          cfn.Properties.DefaultArguments[key] = glueJob.DefaultArguments.customDefaultArguments[key];
+        }
+      })
+    }
     if (glueJob.Connections) {
       cfn.Properties.Connections = {
         Connections: glueJob.Connections,

--- a/src/utils/cloud-formation.utils.ts
+++ b/src/utils/cloud-formation.utils.ts
@@ -55,10 +55,11 @@ export class CloudFormationUtils {
         Tags: glueJob.Tags,
       },
     };
-    if (glueJob.DefaultArguments.customDefaultArguments) {
-      Object.keys(glueJob.DefaultArguments.customDefaultArguments).forEach(key => {
+    if (glueJob.DefaultArguments.customArguments) {
+      Object.keys(glueJob.DefaultArguments.customArguments).forEach(key => {
         if (!cfn.Properties.DefaultArguments[key]) {
-          cfn.Properties.DefaultArguments[key] = glueJob.DefaultArguments.customDefaultArguments[key];
+          const destinationKey = key.startsWith('--') ? key : '--' + key;
+          cfn.Properties.DefaultArguments[destinationKey] = glueJob.DefaultArguments.customArguments[key];
         }
       })
     }


### PR DESCRIPTION
A use case that I require is being able to add my own default arguments to glue jobs, but the default arguments implementation was only supporting the special glue arguments. @toryas if you want me to change this approach, let me know and I will gladly do so.