### PR TITLE
Fix schema typo that blocks serverless 3

### DIFF
--- a/src/schemas/glue.schema.ts
+++ b/src/schemas/glue.schema.ts
@@ -7,5 +7,5 @@ export const GlueSchema = {
     tempDirBucket: { type: "string" },
     tempDirS3Prefix: { type: "string" },
   },
-  require: ["bucketDeploy"],
+  required: ["bucketDeploy"],
 };


### PR DESCRIPTION
@toryas Minor typo that causes issues with serverless version 3, as they've turned on strict verification of schemas.