### PR TITLE
Add support for python 3.9 shell jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Glue:
       Description: # Optional, string
       tempDir: true # Optional true | false
       type: spark # spark / pythonshell # Required
-      glueVersion: python3-2.0 # Required python3-1.0 | python3-2.0 | python2-1.0 | python2-0.9 | scala2-1.0 | scala2-0.9 | scala2-2.0
+      glueVersion: python3-2.0 # Required "python3.9-1.0" | "python3.9-2.0" | "python3.9-3.0" | "python3-1.0" | "python3-2.0" | "python3-3.0" | "python2-1.0" | "python2-0.9" | "scala2-1.0" | "scala2-0.9" | "scala2-2.0" | "scala3-3.0"
       role: arn:aws:iam::000000000:role/someRole # Required
       MaxCapacity: 1 #Optional
       MaxConcurrentRuns: 3 # Optional

--- a/src/domain/default-arguments.ts
+++ b/src/domain/default-arguments.ts
@@ -25,4 +25,5 @@ export class DefaultArguments implements DefaultArgumentsInterface {
   sparkEventLogsPath?: string | undefined;
   tempDir?: any;
   customArguments?: Map<string, string> | undefined;
+  librarySet: string | undefined;
 }

--- a/src/domain/glue-job.ts
+++ b/src/domain/glue-job.ts
@@ -8,13 +8,18 @@ export class GlueJob implements GlueJobInterface {
   tempDir?: boolean;
   type: "spark" | "pythonshell";
   glueVersion:
+    | "python3.9-1.0"
+    | "python3.9-2.0"
+    | "python3.9-3.0"
     | "python3-1.0"
     | "python3-2.0"
+    | "python3-3.0"
     | "python2-1.0"
     | "python2-0.9"
     | "scala2-1.0"
     | "scala2-0.9"
-    | "scala2-2.0";
+    | "scala2-2.0"
+    | "scala3-3.0";
   Description: string;
   role: string;
   MaxCapacity?:number;
@@ -74,6 +79,9 @@ export class GlueJob implements GlueJobInterface {
 
   setGlueVersion(
     glueVersion:
+      | "python3.9-1.0"
+      | "python3.9-2.0"
+      | "python3.9-3.0"
       | "python3-1.0"
       | "python3-2.0"
       | "python3-3.0"
@@ -85,7 +93,7 @@ export class GlueJob implements GlueJobInterface {
       | "scala3-3.0"
   ) {
     let parts = glueVersion.split("-");
-    let pythonVersion = parts[0].match(/\d/)?.toString();
+    let pythonVersion = parts[0].replace(/[A-Za-z]*/, '');
     let language = parts[0].match(/[A-Za-z]*/)?.toString();
     this.pythonVersion = pythonVersion;
     this.glueVersionJob = parts[1];

--- a/src/interfaces/default-arguments.interface.ts
+++ b/src/interfaces/default-arguments.interface.ts
@@ -23,4 +23,5 @@ export interface DefaultArgumentsInterface {
   enableSparkUi?: string;
   sparkEventLogsPath?: string;
   customArguments?: Map<string,string>;
+  librarySet: string;
 }

--- a/src/interfaces/glue-job.interface.ts
+++ b/src/interfaces/glue-job.interface.ts
@@ -7,13 +7,18 @@ export interface GlueJobInterface {
   tempDir?: boolean;
   type: "spark" | "pythonshell";
   glueVersion:
+    | "python3.9-1.0"
+    | "python3.9-2.0"
+    | "python3.9-3.0"
     | "python3-1.0"
     | "python3-2.0"
+    | "python3-3.0"
     | "python2-1.0"
     | "python2-0.9"
     | "scala2-1.0"
     | "scala2-0.9"
-    | "scala2-2.0";
+    | "scala2-2.0"
+    | "scala3-3.0";
   Description: string;
   role: string;
   MaxCapacity?: number;

--- a/src/utils/cloud-formation.utils.ts
+++ b/src/utils/cloud-formation.utils.ts
@@ -53,6 +53,7 @@ export class CloudFormationUtils {
           "--enable-spark-ui": glueJob.DefaultArguments?.enableSparkUi,
           "--spark-event-logs-path":
             glueJob.DefaultArguments?.sparkEventLogsPath,
+          "library-set": glueJob.DefaultArguments?.librarySet,
         },
         Tags: glueJob.Tags,
         Timeout: glueJob.Timeout,


### PR DESCRIPTION
Blog post from AWS: https://aws.amazon.com/blogs/big-data/aws-glue-python-shell-now-supports-python-3-9-with-a-flexible-pre-loaded-environment-and-support-to-install-additional-libraries/