### PR TITLE
Add support for custom logical IDs for jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Glue:
   tempDirS3Prefix: some/s3/key/location/ # optional, default = ''. The job name will be appended to the prefix name
   jobs:
     - name: super-glue-job # Required
+      id: # Optional, string
       scriptPath: src/script.py # Required script will be named with the name after '/' and uploaded to s3Prefix location
       Description: # Optional, string
       tempDir: true # Optional true | false
@@ -178,6 +179,7 @@ createBucketConfig|createBucketConfig| Bucket configuration for creation on S3 |
 |Parameter|Type|Description|Required|
 |-|-|-|-|
 |name|String|name of job|true|
+|id|String|logical ID in CloudFormation for the job|false|
 |Description|String|Description of the job|False|
 |scriptPath|String|script path in the project|true|
 |tempDir|Boolean|flag indicate if job required a temp folder, if true plugin create a bucket for tmp|false|

--- a/src/domain/glue-job.ts
+++ b/src/domain/glue-job.ts
@@ -4,6 +4,7 @@ import { SupportFilesInterface } from "../interfaces/support-files.interface";
 
 export class GlueJob implements GlueJobInterface {
   name: string;
+  id?: string;
   scriptPath: string;
   tempDir?: boolean;
   type: "spark" | "pythonshell";
@@ -42,6 +43,7 @@ export class GlueJob implements GlueJobInterface {
   constructor(job: GlueJobInterface) {
     this.DefaultArguments = job.DefaultArguments ?? {};
     this.name = job.name;
+    this.id = job.id;
     this.scriptPath = job.scriptPath;
     this.role = job.role;
     this.glueVersion = job.glueVersion;

--- a/src/interfaces/glue-job.interface.ts
+++ b/src/interfaces/glue-job.interface.ts
@@ -3,6 +3,7 @@ import { SupportFilesInterface } from "./support-files.interface";
 
 export interface GlueJobInterface {
   name: string;
+  id?: string;
   scriptPath: string;
   tempDir?: boolean;
   type: "spark" | "pythonshell";

--- a/src/services/serverless.service.ts
+++ b/src/services/serverless.service.ts
@@ -72,10 +72,11 @@ export class ServerlessService {
     for (const job of jobs) {
       await this.uploadJobScripts(job);
       await this.uploadSupportFiles(job);
+      const jobCFId = job.id ?? StringUtils.toPascalCase(job.name);
       const jobCFTemplate = CloudFormationUtils.glueJobToCF(job);
       this.helperless.appendToTemplate(
         "resources",
-        StringUtils.toPascalCase(job.name),
+        jobCFId,
         jobCFTemplate
       );
     }


### PR DESCRIPTION
Adds support for custom logical IDs for jobs.

It makes it possible to easily reference jobs with variable names from the same serverless.yml file.

``` yaml
Glue:
  jobs:
    - name: ${self:service}-${self:provider.stage}-convertReports
      id: ConvertReports # -> "Ref: ConvertReports"
```

I have tested it with and without IDs.