### PR TITLE
Add default for s3Prefix

### DIFF
--- a/src/services/serverless.service.ts
+++ b/src/services/serverless.service.ts
@@ -122,7 +122,7 @@ export class ServerlessService {
     const params = {
       Bucket: this.config.bucketDeploy,
       Body: readFileSync(path.join(job.scriptPath)),
-      Key: `${this.config?.s3Prefix}${fileName}`,
+      Key: `${this.config?.s3Prefix ?? "glueJobs/"}${fileName}`,
     };
     await this.awsHelper.uploadFileToS3(params);
     job.setScriptS3Location(`s3://${params.Bucket}/${params.Key}`);


### PR DESCRIPTION
**Issue**:
The ReadMe states that the following parameter is optional and has a default if not set:
`s3Prefix: some/s3/key/location/ # optional, default = 'glueJobs/'`

However in practise this is not the case. If you deploy with some serverless code like the following:
```
Glue:
  bucketDeploy: killians-test-bucket-name-test
  createBucket: true
  jobs:
    - name: test-glue-job
      scriptPath: "src/handler.py"
      Description: "Testing job"
      type: spark # spark / pythonshell
      glueVersion: python3-3.0
      role: <ROLE_ARN> # Required
  triggers:
    - name: test-trigger # Required
      actions: # Required. One or more jobs to trigger
        - name: test-glue-job # Required
```
It will create a file `undefinedhandler.py` in the S3 Bucket provided:
<img width="260" alt="Screenshot 2023-01-27 at 12 48 10" src="https://user-images.githubusercontent.com/16017361/215090827-2494d8e1-e22d-40df-96e0-918bfc090e10.png">

**Fix**:
This is a pretty easy fix. I just added a default string for s3Prefix as stated in the ReadMe.

I've tested this with and without the `s3Prefix` param and it is working as expected:
- With: Creates the correct file structure
<img width="239" alt="Screenshot 2023-01-27 at 12 48 21" src="https://user-images.githubusercontent.com/16017361/215090970-0145d8dc-7723-4490-aa85-f5dd315b342c.png">

- Without: Defaults to a file structure of `glueJobs/`
<img width="215" alt="Screenshot 2023-01-27 at 12 48 16" src="https://user-images.githubusercontent.com/16017361/215091015-22e427d3-81ab-47f6-bcd3-f487f9b97ad9.png">

If there is anything else I need to test/change please let me know.

