### PR TITLE
fix: only added tempdir when property is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ Only run `serverless deploy`
 # Changelog
 <a name="changelog"></a>
 
+## [2.12.1] - 2023-05-31
+
+### Fix
+- Fixed tempDir being added when set to false
 
 ## [2.12.0] - 2023-02-09
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-glue",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Serverless plugin to deploy Glue Jobs",
   "main": "index.js",
   "scripts": {

--- a/src/utils/cloud-formation.utils.ts
+++ b/src/utils/cloud-formation.utils.ts
@@ -23,7 +23,6 @@ export class CloudFormationUtils {
         DefaultArguments: {
           "--additional-python-modules": glueJob.DefaultArguments?.additionalPythonModules,
           "--job-language": glueJob.DefaultArguments?.jobLanguage,
-          "--TempDir": glueJob.DefaultArguments?.tempDir ?? "",
           "--class": glueJob.DefaultArguments?.class,
           "--scriptLocation": glueJob.DefaultArguments?.scriptLocation,
           "--extra-py-files": glueJob.DefaultArguments?.extraPyFiles,
@@ -62,6 +61,12 @@ export class CloudFormationUtils {
         SecurityConfiguration: glueJob.SecurityConfiguration
       },
     };
+    if (glueJob.DefaultArguments?.tempDir) {
+      cfn.Properties.DefaultArguments = {
+        ...cfn.Properties.DefaultArguments,
+        "--TempDir": glueJob.DefaultArguments.tempDir,
+      }
+    }
     if (glueJob.DefaultArguments.customArguments) {
       const customArguments = CloudFormationUtils.parseCustomArguments(glueJob.DefaultArguments.customArguments);
       cfn.Properties.DefaultArguments = {


### PR DESCRIPTION
Ref: Job fails if run inmediatly after deployed, works after saving without any change #52