### PR TITLE
included job queuing feature

### DIFF
--- a/src/domain/glue-job.ts
+++ b/src/domain/glue-job.ts
@@ -44,6 +44,7 @@ export class GlueJob implements GlueJobInterface {
   MaxRetries: number;
   SupportFiles: SupportFilesInterface[];
   SecurityConfiguration?: string;
+  jobRunQueuingEnabled?: boolean;
 
 
   constructor(job: GlueJobInterface) {
@@ -68,6 +69,7 @@ export class GlueJob implements GlueJobInterface {
     this.MaxRetries = job.MaxRetries;
     this.SupportFiles = job.SupportFiles;
     this.SecurityConfiguration = job.SecurityConfiguration;
+    this.jobRunQueuingEnabled = job.jobRunQueuingEnabled;
   }
 
   setScriptS3Location(s3url: string) {

--- a/src/domain/glue-job.ts
+++ b/src/domain/glue-job.ts
@@ -44,7 +44,7 @@ export class GlueJob implements GlueJobInterface {
   MaxRetries: number;
   SupportFiles: SupportFilesInterface[];
   SecurityConfiguration?: string;
-  jobRunQueuingEnabled?: boolean;
+  JobRunQueuingEnabled?: boolean;
 
 
   constructor(job: GlueJobInterface) {
@@ -69,7 +69,7 @@ export class GlueJob implements GlueJobInterface {
     this.MaxRetries = job.MaxRetries;
     this.SupportFiles = job.SupportFiles;
     this.SecurityConfiguration = job.SecurityConfiguration;
-    this.jobRunQueuingEnabled = job.jobRunQueuingEnabled;
+    this.JobRunQueuingEnabled = job.JobRunQueuingEnabled;
   }
 
   setScriptS3Location(s3url: string) {

--- a/src/interfaces/glue-job.interface.ts
+++ b/src/interfaces/glue-job.interface.ts
@@ -24,5 +24,5 @@ export interface GlueJobInterface {
   MaxRetries: number;
   SupportFiles: SupportFilesInterface[];
   SecurityConfiguration?: string;
-  jobRunQueuingEnabled?: boolean;
+  JobRunQueuingEnabled?: boolean;
 }

--- a/src/interfaces/glue-job.interface.ts
+++ b/src/interfaces/glue-job.interface.ts
@@ -24,4 +24,5 @@ export interface GlueJobInterface {
   MaxRetries: number;
   SupportFiles: SupportFilesInterface[];
   SecurityConfiguration?: string;
+  jobRunQueuingEnabled?: boolean;
 }

--- a/src/utils/cloud-formation.utils.ts
+++ b/src/utils/cloud-formation.utils.ts
@@ -87,8 +87,8 @@ export class CloudFormationUtils {
         cfn.Properties.NumberOfWorkers = glueJob.NumberOfWorkers;
       }
     }
-    if (glueJob.jobRunQueuingEnabled !== undefined) {
-      cfn.Properties.JobRunQueuingEnabled = glueJob.jobRunQueuingEnabled;
+    if (glueJob.JobRunQueuingEnabled !== undefined) {
+      cfn.Properties.JobRunQueuingEnabled = glueJob.JobRunQueuingEnabled;
     }
 
     return cfn;

--- a/src/utils/cloud-formation.utils.ts
+++ b/src/utils/cloud-formation.utils.ts
@@ -87,6 +87,9 @@ export class CloudFormationUtils {
         cfn.Properties.NumberOfWorkers = glueJob.NumberOfWorkers;
       }
     }
+    if (glueJob.jobRunQueuingEnabled !== undefined) {
+      cfn.Properties.JobRunQueuingEnabled = glueJob.jobRunQueuingEnabled;
+    }
 
     return cfn;
   }


### PR DESCRIPTION
This change will allow the plugin to use the recently added job queuing feature:
https://aws.amazon.com/blogs/big-data/introducing-job-queuing-to-scale-your-aws-glue-workloads/