### PR TITLE
add enable-observability-metrics to DefaultArguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Glue:
         enableRenameAlgorithmV2: string # Optional
         enableGlueDatacatalog: string # Optional
         enableMetrics: string # Optional
+        enableObservabilityMetrics: string # Optional
         enableContinuousCloudwatchLog: string # Optional
         enableContinuousLogFilter: string # Optional
         continuousLogLogGroup: string # Optional

--- a/src/domain/default-arguments.ts
+++ b/src/domain/default-arguments.ts
@@ -17,6 +17,7 @@ export class DefaultArguments implements DefaultArgumentsInterface {
   enableRenameAlgorithmV2?: string | undefined;
   enableGlueDatacatalog?: string | undefined;
   enableMetrics?: string | undefined;
+  enableObservabilityMetrics?: string | undefined;
   enableContinuousCloudwatchLog?: string | undefined;
   enableContinuousLogFilter?: string | undefined;
   continuousLogLogGroup?: string | undefined;

--- a/src/interfaces/default-arguments.interface.ts
+++ b/src/interfaces/default-arguments.interface.ts
@@ -16,6 +16,7 @@ export interface DefaultArgumentsInterface {
   enableRenameAlgorithmV2?: string;
   enableGlueDatacatalog?: string;
   enableMetrics?: string;
+  enableObservabilityMetrics?: string;
   enableContinuousCloudwatchLog?: string;
   enableContinuousLogFilter?: string;
   continuousLogLogGroup?: string;

--- a/src/utils/cloud-formation.utils.ts
+++ b/src/utils/cloud-formation.utils.ts
@@ -40,6 +40,8 @@ export class CloudFormationUtils {
           "--enable-glue-datacatalog":
             glueJob.DefaultArguments?.enableGlueDatacatalog,
           "--enable-metrics": glueJob.DefaultArguments?.enableMetrics,
+          "--enable-observability-metrics": 
+            glueJob.DefaultArguments?.enableObservabilityMetrics,
           "--enable-continuous-cloudwatch-log":
             glueJob.DefaultArguments?.enableContinuousCloudwatchLog,
           "--enable-continuous-log-filter":


### PR DESCRIPTION
https://docs.aws.amazon.com/glue/latest/dg/monitoring-awsglue-with-cloudwatch-metrics.html
added enable-observability-metrics to default argument for enableing glue observability metric